### PR TITLE
Unknown parameters in ini file

### DIFF
--- a/uniconfig.go
+++ b/uniconfig.go
@@ -181,6 +181,12 @@ func SetFromParsedIniFile(configItems []*ConfigItem, ini map[string]string) {
 		v, ok := ini[k]
 		if ok {
 			flag.Set(item.CmdFlagName(), v)
+			delete(ini, k)
+		}
+	}
+	if len(ini) > 0 {
+		for k, _ := range ini {
+			log.Panicf("Unknown parameter in config file: %s", k)
 		}
 	}
 }

--- a/uniconfig_test.go
+++ b/uniconfig_test.go
@@ -3,6 +3,7 @@ package uniconfig
 import (
 	"flag"
 	"os"
+	"runtime/debug"
 	"strings"
 	"testing"
 )
@@ -14,6 +15,7 @@ func AssertEquals(t *testing.T, actual, expected interface{}) {
 	case string:
 		if expected, ok := expected.(string); ok {
 			if actual != expected {
+				debug.PrintStack()
 				t.Fatalf("%s != %s", actual, expected)
 			}
 		} else {
@@ -22,20 +24,25 @@ func AssertEquals(t *testing.T, actual, expected interface{}) {
 	case int:
 		if expected, ok := expected.(int); ok {
 			if actual != expected {
+				debug.PrintStack()
 				t.Fatalf("%d != %d", actual, expected)
 			}
 		} else {
+			debug.PrintStack()
 			t.Fatalf("Cannot compare: %v and %v (not int)", actual, expected)
 		}
 	case bool:
 		if expected, ok := expected.(bool); ok {
 			if actual != expected {
+				debug.PrintStack()
 				t.Fatalf("%s != %s", actual, expected)
 			}
 		} else {
+			debug.PrintStack()
 			t.Fatalf("Cannot compare: %v and %v (not bool)", actual, expected)
 		}
 	default:
+		debug.PrintStack()
 		t.Fatalf("Cannot compare: %v and %v", actual, expected)
 	}
 }
@@ -123,9 +130,7 @@ func TestLoadFromIni(t *testing.T) {
 
 		[Nested1]
 		A  = sometag
-		irrelevant = ignored option
 
-		number = 14
 `
 
 	dict := ParseIniFile(strings.NewReader(testIni))

--- a/uniconfig_test.go
+++ b/uniconfig_test.go
@@ -140,6 +140,28 @@ func TestLoadFromIni(t *testing.T) {
 	AssertEquals(t, config.Nested1.A, "sometag")
 	AssertEquals(t, config.Nested1.B, "baa")
 	AssertEquals(t, config.Nested2.Zzz, false)
+
+	testIni2 := `
+		debug = true
+		count = 65535
+		; this is a comment
+		# also a comment
+
+		[Nested1]
+		A  = sometag
+		unknown_parameter = must panic
+
+`
+	dict2 := ParseIniFile(strings.NewReader(testIni2))
+
+	func() {
+		defer func() {
+			if err := recover(); err != nil {
+			}
+		}()
+		SetFromParsedIniFile(items, dict2)
+		t.Fatal("Test must panic with unknown parameter error")
+	}()
 }
 
 func TestParseCmdline(t *testing.T) {


### PR DESCRIPTION
I believe that uniconfig should throw panic if an ini file contains unknown keys (because usually it means that you've just misspelled parameter name)